### PR TITLE
Admins can see Camper age in roster detail page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Admins can see Camper age in roster detail page.
+
 ### Changed
 
 - Fixed broken CSV download links for Admins.

--- a/client/src/Admin/AdminRosters/AdminRoster.jsx
+++ b/client/src/Admin/AdminRosters/AdminRoster.jsx
@@ -1,14 +1,9 @@
 import React, { Component } from "react";
-import moment from "moment";
 import _ from "lodash";
 import SearchTable from "../../SearchTable/SearchTable";
 import { Link } from "react-router-dom";
 
 class AdminRoster extends Component {
-  formatDate(date) {
-    return moment.utc(date).format("MM/DD/YYYY");
-  }
-
   render() {
     return (
       <div className="admin-roster">
@@ -31,6 +26,11 @@ class AdminRoster extends Component {
               key: "camper.lastName",
               name: "Last Name",
               displayFunc: item => item.camper.lastName
+            },
+            {
+              key: "camper.age",
+              name: "Age",
+              displayFunc: item => item.camper.age
             },
             {
               key: "camper.swimmingStrength",


### PR DESCRIPTION
Fixes #113 

### Added

 - Admins can see Camper age in roster detail page.